### PR TITLE
Switch payment integration to Fondy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Before deploying the site you should update several placeholders in `index.html`
 - **Facebook Pixel** – uncomment the snippet and set `YOUR_PIXEL_ID` if you use Facebook advertising.
 - **Hotjar** – uncomment the code and provide your Hotjar ID if desired.
 - **Social links** – update the Instagram, Facebook and TikTok URLs in the footer.
-- **Payment integration** – update the `LEMON_CHECKOUT_URL` constant in `scripts.js` with your Lemon Squeezy checkout link. Include `<script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>` in `index.html` if you want to use the popup widget. Configure webhooks in your Lemon Squeezy dashboard to `https://yourdomain.com/webhooks/lemon` (or your chosen URL) so you can confirm orders after payment.
+- **Payment integration** – update the `FONDY_CHECKOUT_URL` constant in `scripts.js` with your Fondy payment URL or merchant ID. Include `<script src="https://pay.fondy.eu/latest/checkout.js"></script>` in `index.html` if you want to use Fondy’s widget.
 - **Images and favicons** – provide an `og-preview.jpg` image (1200×630) for social sharing and create favicon files (`favicon-32x32.png`, `favicon-16x16.png`, `apple-touch-icon.png`).
 
 The main styles are located in `styles.css` and behaviour scripts in `scripts.js`.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     3. Створіть favicon файли або використайте https://favicon.io
     4. Опціонально: розкоментуйте Facebook Pixel та Hotjar
     5. Оновіть соціальні посилання в футері
-    6. Підключіть Stripe для платежів
+    6. Підключіть Fondy для платежів
     
     Tracking події:
     - click_order_button - клік на кнопку замовлення
@@ -554,6 +554,8 @@
         </div>
     </div>
 
+    <!-- Fondy widget script (optional) -->
+    <!-- <script src="https://pay.fondy.eu/latest/checkout.js"></script> -->
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,5 +1,5 @@
-        // Lemon Squeezy checkout URL
-        const LEMON_CHECKOUT_URL = 'https://your-store.lemonsqueezy.com/checkout';
+        // Fondy checkout URL
+        const FONDY_CHECKOUT_URL = 'https://pay.fondy.eu/merchant/checkout';
 
         // Smooth scrolling
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
@@ -162,12 +162,8 @@
             };
             sessionStorage.setItem('pendingOrder', JSON.stringify(orderInfo));
 
-            // Redirect to Lemon Squeezy checkout or open the widget
-            if (typeof createLemonSqueezy !== 'undefined') {
-                createLemonSqueezy(LEMON_CHECKOUT_URL);
-            } else {
-                window.location.href = LEMON_CHECKOUT_URL;
-            }
+            // Redirect to Fondy checkout link
+            window.location.href = FONDY_CHECKOUT_URL;
         });
 
         // Intersection Observer for fade-in animations


### PR DESCRIPTION
## Summary
- note Fondy instead of Stripe in the site comments
- add placeholder for Fondy widget script
- document Fondy configuration in README
- rename checkout constant and redirect logic for Fondy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842c937c704832087f173b21e8637c3