### PR TITLE
Switch to generic checkout constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before deploying the site you should update several placeholders in `index.html`
 - **Hotjar** – uncomment the code and provide your Hotjar ID if desired.
 - **Social links** – update the Instagram, Facebook and TikTok URLs in the footer.
 
-- **Payment integration** – update the `FONDY_CHECKOUT_URL` constant in `scripts.js` with your Fondy payment URL or merchant ID. Include `<script src="https://pay.fondy.eu/latest/checkout.js"></script>` in `index.html` if you want to use Fondy’s widget.
+- **Payment integration** – set the `CHECKOUT_URL` constant in `scripts.js` to your payment provider's checkout link. Optionally include the provider's widget script in `index.html` if it exposes a `createCheckoutWidget()` function. Configure webhooks to `https://yourdomain.com/webhooks/payment` (or your chosen URL) so you can confirm orders after payment.
 
 - **Images and favicons** – provide an `og-preview.jpg` image (1200×630) for social sharing and create favicon files (`favicon-32x32.png`, `favicon-16x16.png`, `apple-touch-icon.png`).
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     3. Створіть favicon файли або використайте https://favicon.io
     4. Опціонально: розкоментуйте Facebook Pixel та Hotjar
     5. Оновіть соціальні посилання в футері
-    6. Підключіть Fondy для платежів
+    6. Вкажіть CHECKOUT_URL та підключіть скрипт платіжного провайдера
     
     Tracking події:
     - click_order_button - клік на кнопку замовлення
@@ -554,8 +554,8 @@
         </div>
     </div>
 
-    <!-- Fondy widget script (optional) -->
-    <!-- <script src="https://pay.fondy.eu/latest/checkout.js"></script> -->
+    <!-- Payment provider widget script (optional) -->
+    <!-- <script src="https://pay.provider.com/latest/widget.js"></script> -->
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,5 +1,5 @@
-        // Fondy checkout URL
-        const FONDY_CHECKOUT_URL = 'https://pay.fondy.eu/merchant/checkout';
+        // Checkout URL for your payment provider
+        const CHECKOUT_URL = 'https://pay.fondy.eu/merchant/checkout';
 
         // Smooth scrolling
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
@@ -162,8 +162,12 @@
             };
             sessionStorage.setItem('pendingOrder', JSON.stringify(orderInfo));
 
-            // Redirect to Fondy checkout link
-            window.location.href = FONDY_CHECKOUT_URL;
+            // Redirect to the checkout link or open your provider's widget
+            if (typeof createCheckoutWidget !== 'undefined') {
+                createCheckoutWidget(CHECKOUT_URL);
+            } else {
+                window.location.href = CHECKOUT_URL;
+            }
         });
 
         // Intersection Observer for fade-in animations


### PR DESCRIPTION
## Summary
- rename checkout constant to provider-neutral CHECKOUT_URL
- call createCheckoutWidget when available
- document generic payment instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842eaabbbe883208205724cec8088c9