### PR TITLE
Add success page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Before deploying the site you should update several placeholders in `index.html`
 - **Hotjar** – uncomment the code and provide your Hotjar ID if desired.
 - **Social links** – update the Instagram, Facebook and TikTok URLs in the footer.
 - **Payment integration** – update the `LEMON_CHECKOUT_URL` constant in `scripts.js` with your Lemon Squeezy checkout link. Include `<script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>` in `index.html` if you want to use the popup widget. Configure webhooks in your Lemon Squeezy dashboard to `https://yourdomain.com/webhooks/lemon` (or your chosen URL) so you can confirm orders after payment.
+- **Fondy redirect** – if you use Fondy for payments, set its success URL to `/success.html`. This page reads the `pendingOrder` saved in `sessionStorage` and shows a brief summary after checkout.
 - **Images and favicons** – provide an `og-preview.jpg` image (1200×630) for social sharing and create favicon files (`favicon-32x32.png`, `favicon-16x16.png`, `apple-touch-icon.png`).
 
 The main styles are located in `styles.css` and behaviour scripts in `scripts.js`.

--- a/styles.css
+++ b/styles.css
@@ -897,3 +897,26 @@
             opacity: 1;
             transform: translateY(0);
         }
+
+/* Success Page */
+.success-container {
+    max-width: 600px;
+    margin: 8rem auto;
+    padding: 2rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    text-align: center;
+}
+
+.success-container h1 {
+    margin-bottom: 1rem;
+    font-size: 2rem;
+    background: linear-gradient(135deg, var(--primary), var(--secondary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.success-container p {
+    margin-bottom: 0.5rem;
+}

--- a/success.html
+++ b/success.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Order Success - NeiroTunes</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="success-container">
+        <h1>Thank you for your order!</h1>
+        <p id="orderDetails"></p>
+        <p id="noData" style="display:none;">We couldn't find any order information.</p>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const detailsEl = document.getElementById('orderDetails');
+            const noDataEl = document.getElementById('noData');
+            const raw = sessionStorage.getItem('pendingOrder');
+
+            if (raw) {
+                try {
+                    const order = JSON.parse(raw);
+                    let html = '';
+                    html += `Name: ${order.name}<br>`;
+                    html += `Email: ${order.email}<br>`;
+                    html += `Package: ${order.package}<br>`;
+                    if (order.genre) html += `Genre: ${order.genre}<br>`;
+                    if (order.rights) html += 'Rights Transfer included<br>';
+                    if (order.rush) html += 'Rush delivery<br>';
+                    html += `Total: $${order.total}`;
+                    detailsEl.innerHTML = html;
+                } catch (err) {
+                    detailsEl.style.display = 'none';
+                    noDataEl.style.display = 'block';
+                }
+            } else {
+                detailsEl.style.display = 'none';
+                noDataEl.style.display = 'block';
+            }
+
+            sessionStorage.removeItem('pendingOrder');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show order details on new `success.html`
- add styling for success page container
- document Fondy redirect in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842cb2e878c8320ade92b166fc9bf01